### PR TITLE
フォルダ一覧取得で各フォルダ内のメモ件数を取得するようにした

### DIFF
--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -120,4 +120,6 @@ pub struct FolderInfo {
     pub name: String,
     /// フォルダ更新日時
     pub updated_at: String,
+    /// フォルダにあるメモの件数
+    pub memo_count: i32,
 }

--- a/src/types/invokeGenerate.d.ts
+++ b/src/types/invokeGenerate.d.ts
@@ -48,6 +48,8 @@ export interface FolderInfo {
 	name: string;
 	/** フォルダ更新日時 */
 	updated_at: string;
+	/** フォルダにあるメモの件数 */
+	memo_count: number;
 }
 
 export interface MemoListInfo {


### PR DESCRIPTION
## 関連するissue

- なし

## 概要

- フォルダ一覧取得で各フォルダ内のメモ件数を取得するようにした

## 変更内容

- [ ] バグ修正
- [x] 新機能
- [ ] その他

## チェックリスト

- [x] コードがプロジェクトのスタイルガイドラインに従っている
- [x] 自己レビューを行った
- [x] 必要なドキュメントを更新した

---

このPRがプロジェクトをより良くする一歩です。
レビューを楽しみにしています！
