### PR TITLE
メモタイトルをメモを開いた状態で編集しやすいボタンを追加

### DIFF
--- a/src/components/presentation/_EditArea/EditorInfo.tsx
+++ b/src/components/presentation/_EditArea/EditorInfo.tsx
@@ -1,6 +1,8 @@
-import { Box, Flex, Text } from "@chakra-ui/react";
+import { Box, Flex, Text, IconButton, Button } from "@chakra-ui/react";
 import { Tag } from "@/components/ui/tag";
 import { CustomInput } from "@/components/parts/CustomInput";
+import { useState } from "react";
+import { HiPencil } from "react-icons/hi";
 
 export type EditorInfoProps = {
   memoTitle: string;
@@ -8,6 +10,7 @@ export type EditorInfoProps = {
   addTag: (tag: string) => void;
   removeTag: (tag: string) => void;
   availableTags: string[];
+  onTitleChange: (newTitle: string) => void;
 };
 
 export const EditorInfo = ({
@@ -16,7 +19,11 @@ export const EditorInfo = ({
   addTag,
   removeTag,
   availableTags,
+  onTitleChange,
 }: EditorInfoProps) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editingTitle, setEditingTitle] = useState(memoTitle);
+
   const handleKeyPress: React.KeyboardEventHandler<HTMLInputElement> = (e) => {
     if (e.key === "Enter") {
       addTag(e.currentTarget.value);
@@ -24,10 +31,50 @@ export const EditorInfo = ({
     }
   };
 
+  const handleEditClick = () => {
+    setEditingTitle(memoTitle);
+    setIsEditing(true);
+  };
+
+  const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setEditingTitle(e.target.value);
+  };
+
+  const handleSave = () => {
+    setIsEditing(false);
+    onTitleChange(editingTitle);
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+    setEditingTitle(memoTitle);
+  };
+
   return (
     <Box px="4" py="2">
       {/* ファイル名 */}
-      <Text fontSize="xl">{memoTitle}</Text>
+      {isEditing ? (
+        <Flex alignItems="center" gap={2} mb={2}>
+          <CustomInput
+            type="text"
+            value={editingTitle}
+            onChange={handleTitleChange}
+          />
+          <Button onClick={handleSave} colorPalette="teal">
+            Save
+          </Button>
+          <Button onClick={handleCancel} variant="subtle">
+            Cancel
+          </Button>
+        </Flex>
+      ) : (
+        <Flex alignItems="center" gap={2} mb={2}>
+          <Text fontSize="xl">{memoTitle}</Text>
+          <IconButton onClick={handleEditClick} variant="ghost">
+            <HiPencil />
+          </IconButton>
+        </Flex>
+      )}
       {/* 編集可能なタグ一覧 */}
       <Flex gap={2} alignItems="center">
         {tags.map((tag, index) => (


### PR DESCRIPTION
## 関連するissue

- なし

## 概要

メモのタイトル横に編集アイコンを追加

<img width="998" alt="スクリーンショット 2025-02-27 0 26 03" src="https://github.com/user-attachments/assets/13dfcae7-f711-4bd3-a639-e00a48e0c7cc" />
<img width="595" alt="スクリーンショット 2025-02-27 0 26 15" src="https://github.com/user-attachments/assets/63456088-e1ea-4011-9ec9-e285413503d1" />


## 変更内容

- [ ] バグ修正
- [x] 新機能
- [ ] その他

## チェックリスト

- [ ] コードがプロジェクトのスタイルガイドラインに従っている
- [x] 自己レビューを行った
- [ ] 必要なドキュメントを更新した

---

このPRがプロジェクトをより良くする一歩です。
レビューを楽しみにしています！
