### PR TITLE
monaco-markdownを追加し、エディタにMarkdown拡張機能を統合

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@uiw/react-md-editor": "^4.0.5",
         "github-markdown-css": "^5.8.1",
         "mermaid": "^11.4.1",
+        "monaco-markdown": "^0.0.12",
         "next-themes": "^0.4.4",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -11653,6 +11654,20 @@
       "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
       "peer": true
     },
+    "node_modules/monaco-markdown": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/monaco-markdown/-/monaco-markdown-0.0.12.tgz",
+      "integrity": "sha512-KkGheL2pUazZJY2DfBqpHuMQOjILkbYGNtF5MzpT3ZWupKjunkpL7ByKTllBQGKKcVNt5nuRHl7YsKFskWlc6Q==",
+      "dependencies": {
+        "monaco-editor": "0.30.1",
+        "string-similarity": "^3.0.0"
+      }
+    },
+    "node_modules/monaco-markdown/node_modules/monaco-editor": {
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.30.1.tgz",
+      "integrity": "sha512-B/y4+b2O5G2gjuxIFtCE2EkM17R2NM7/3F8x0qcPsqy4V83bitJTIO4TIeZpYlzu/xy6INiY/+84BEm6+7Cmzg=="
+    },
     "node_modules/mri": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
@@ -14749,6 +14764,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/string-similarity": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-3.0.0.tgz",
+      "integrity": "sha512-7kS7LyTp56OqOI2BDWQNVnLX/rCxIQn+/5M0op1WV6P8Xx6TZNdajpuqQdiJ7Xx+p1C5CsWMvdiBp9ApMhxzEQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info."
     },
     "node_modules/string-width": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@uiw/react-md-editor": "^4.0.5",
     "github-markdown-css": "^5.8.1",
     "mermaid": "^11.4.1",
+    "monaco-markdown": "^0.0.12",
     "next-themes": "^0.4.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/parts/MarkdownPreview.tsx
+++ b/src/components/parts/MarkdownPreview.tsx
@@ -26,7 +26,7 @@ export const Mermaid: React.FC<MermaidProps> = (props) => {
         const { svg } = await mermaid.render(`m${crypto.randomUUID()}`, code);
         outputRef.current.innerHTML = svg;
       } catch (error) {
-        console.error(error);
+        console.warn(error);
         outputRef.current.innerHTML = "Invalid syntax";
       }
     }

--- a/src/components/parts/editor/Editor.tsx
+++ b/src/components/parts/editor/Editor.tsx
@@ -1,4 +1,5 @@
 import ReactMonacoEditor from "@monaco-editor/react";
+import { MonacoMarkdownExtension } from "monaco-markdown";
 
 type EditorProps = {
   value: string;
@@ -17,6 +18,11 @@ export const Editor = (props: EditorProps) => {
         if (value !== undefined) {
           props.onChange(value);
         }
+      }}
+      onMount={(editor) => {
+        const mmd = new MonacoMarkdownExtension();
+        // @ts-ignore monaco-markdownの使用しているmonaco-editorのバージョンが古く型定義があってないと思われる
+        mmd.activate(editor);
       }}
       options={{
         minimap: {


### PR DESCRIPTION
## 関連するissue

- このプルリクエストが解決するIssue番号を記載してください。

## 概要

https://www.npmjs.com/package/monaco-markdown/v/0.0.12

monaco-markdownというライブラリを導入し、マークダウン記入の補助をできるようにしました。

![2024-106](https://github.com/user-attachments/assets/512fd699-7d93-48fb-8188-4160c1404fc7)

## 変更内容

- [ ] バグ修正
- [x] 新機能
- [ ] その他

## チェックリスト

- [ ] コードがプロジェクトのスタイルガイドラインに従っている
- [ ] 自己レビューを行った
- [ ] 必要なドキュメントを更新した

---

このPRがプロジェクトをより良くする一歩です。
レビューを楽しみにしています！
