### PR TITLE
メモ一覧が見づらいのでUIを更新

### DIFF
--- a/src/components/parts/MemoItem.tsx
+++ b/src/components/parts/MemoItem.tsx
@@ -58,11 +58,12 @@ export const MemoItem = ({
     >
       <Box
         position="relative"
-        boxShadow="xs"
-        boxShadowColor="border"
+        boxShadow="sm"
         bg={selected ? "bg.subtle" : "bg"}
         p={1}
         cursor="pointer"
+        as="button"
+        textAlign="left"
         _hover={{
           bg: "bg.emphasized",
         }}

--- a/src/components/parts/MemoItem.tsx
+++ b/src/components/parts/MemoItem.tsx
@@ -11,6 +11,7 @@ import {
   MenuRoot,
   MenuTrigger,
 } from "@/components/ui/menu";
+import { Tooltip } from "@/components/ui/tooltip";
 
 export type MemoItemProps = {
   id: number;
@@ -48,70 +49,78 @@ export const MemoItem = ({
   };
 
   return (
-    <Box
-      position="relative"
-      borderWidth={1}
-      borderColor="border"
-      bg={selected ? "bg.emphasized" : "bg.subtle"}
-      p={2}
-      borderRadius={2}
-      cursor="pointer"
-      _hover={{
-        borderColor: "border.inverted",
-      }}
-      onClick={() => onClickMemo(id)}
+    <Tooltip
+      content={
+        <Text color="fg.subtle" textStyle="sm">
+          last updated: {updatedAt}
+        </Text>
+      }
     >
-      {resultIcon ? (
-        <Float placement="top-end">
-          <Circle size={3} bg="teal.emphasized"></Circle>
-        </Float>
-      ) : null}
-      <HStack justifyContent="space-between" alignItems="flex-start">
-        <Text textStyle="md">{name}</Text>
-        <MenuRoot onSelect={handleSelectMenu}>
-          <MenuTrigger asChild>
-            <IconButton
-              size="xs"
-              aria-label="More options"
-              variant="outline"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <HiDotsHorizontal />
-            </IconButton>
-          </MenuTrigger>
-          <MenuContent>
-            <MenuItem
-              value="move-folder"
-              cursor="pointer"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <HiFolderOpen />
-              <Box flex="1">フォルダ移動</Box>
-            </MenuItem>
-            <MenuItem
-              value="rename-memo"
-              cursor="pointer"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <HiPencil />
-              <Box flex="1">名前変更</Box>
-            </MenuItem>
-            <MenuItem
-              value="delete-memo"
-              cursor="pointer"
-              color="fg.error"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <HiTrash />
-              <Box flex="1">削除</Box>
-            </MenuItem>
-          </MenuContent>
-        </MenuRoot>
-      </HStack>
-
-      <Text color="fg.subtle" textStyle="sm">
-        {updatedAt}
-      </Text>
-    </Box>
+      <Box
+        position="relative"
+        boxShadow="xs"
+        boxShadowColor="border"
+        bg={selected ? "bg.subtle" : "bg"}
+        p={1}
+        cursor="pointer"
+        _hover={{
+          bg: "bg.emphasized",
+        }}
+        onClick={() => onClickMemo(id)}
+      >
+        {resultIcon ? (
+          <Float placement="top-end">
+            <Circle size={3} bg="teal.emphasized"></Circle>
+          </Float>
+        ) : null}
+        <HStack justifyContent="space-between" alignItems="center">
+          <Box w="100%">
+            <Text textStyle="sm">{name}</Text>
+            <Text color="fg.subtle" textStyle="xs">
+              {updatedAt}
+            </Text>
+          </Box>
+          <MenuRoot onSelect={handleSelectMenu}>
+            <MenuTrigger asChild>
+              <IconButton
+                size="xs"
+                aria-label="More options"
+                variant="outline"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <HiDotsHorizontal />
+              </IconButton>
+            </MenuTrigger>
+            <MenuContent>
+              <MenuItem
+                value="move-folder"
+                cursor="pointer"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <HiFolderOpen />
+                <Box flex="1">フォルダ移動</Box>
+              </MenuItem>
+              <MenuItem
+                value="rename-memo"
+                cursor="pointer"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <HiPencil />
+                <Box flex="1">名前変更</Box>
+              </MenuItem>
+              <MenuItem
+                value="delete-memo"
+                cursor="pointer"
+                color="fg.error"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <HiTrash />
+                <Box flex="1">削除</Box>
+              </MenuItem>
+            </MenuContent>
+          </MenuRoot>
+        </HStack>
+      </Box>
+    </Tooltip>
   );
 };

--- a/src/components/presentation/MemoList.tsx
+++ b/src/components/presentation/MemoList.tsx
@@ -43,7 +43,6 @@ export const MemoList: React.FC<MemoListProps> = ({
       w={240}
       maxH="100vh"
       overflowY="auto"
-      px={3}
       pb={3}
       bg="bg"
       borderRightWidth={1}
@@ -69,7 +68,7 @@ export const MemoList: React.FC<MemoListProps> = ({
         </Flex>
       </Box>
 
-      <Flex direction="column" gap={2} mt={3}>
+      <Flex direction="column" mt={2} gap={0.5}>
         {memos.map((memo) => (
           <MemoItem key={memo.id} {...memo} />
         ))}


### PR DESCRIPTION
## 関連するissue

- なし

## 概要

メモ一覧が見づらかったのでマージン、パディングを調整しリストの一覧に出るメモの数を増やした

<img width="681" alt="スクリーンショット 2025-06-16 22 49 03" src="https://github.com/user-attachments/assets/c8be6b31-b945-46f0-9bb6-468ef957853c" />

## 変更内容

- [ ] バグ修正
- [ ] 新機能
- [x] その他

## チェックリスト

- [x] コードがプロジェクトのスタイルガイドラインに従っている
- [x] 自己レビューを行った
- [x] 必要なドキュメントを更新した

---

このPRがプロジェクトをより良くする一歩です。
レビューを楽しみにしています！


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - メモアイテムに「最終更新日時」をホバー時に表示するツールチップを追加し、レイアウトと視覚的統合を改善。
  - メモアイテムのテキストスタイルと配置を調整し、より洗練された見た目に。
  - 更新日時の表示をメモアイテム内に統合し、ツールチップで補足。

- **Style**
  - メモリストの水平・垂直スペースを削減し、よりコンパクトなレイアウトに。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->