### PR TITLE
メモをドラッグアンドドロップで所属フォルダを移動することができるように機能追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "luma-note",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "luma-note",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "dependencies": {
         "@chakra-ui/react": "^3.2.3",
+        "@dnd-kit/core": "^6.3.1",
         "@emotion/react": "^11.14.0",
         "@monaco-editor/react": "^4.7.0",
         "@tanstack/react-query": "^5.62.8",
@@ -447,6 +448,42 @@
       "version": "11.0.3",
       "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
       "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ=="
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.13.5",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@chakra-ui/react": "^3.2.3",
+    "@dnd-kit/core": "^6.3.1",
     "@emotion/react": "^11.14.0",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.62.8",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,11 +5,9 @@ import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { ColorModeProvider } from "@/components/ui/color-mode";
 import { AppSettingProvider } from "@/components/context/AppSettingContext";
 
-import { FolderList } from "@/components/container/FolderList";
-import { MemoListContainer } from "@/components/container/MemoList";
-import { EditArea } from "@/components/container/EditArea";
 import { HeaderContainer } from "@/components/container/Header";
 import { ConfigMenuContainer } from "@/components/container/ConfigMenu";
+import { EditorContainer } from "@/components/container/EditorContainer";
 
 const queryClient = new QueryClient();
 
@@ -27,11 +25,7 @@ function App() {
                   {/* メニューエリア */}
                   <HeaderContainer ConfigMenuButton={ConfigMenuContainer} />
                   {/* エディターエリア */}
-                  <section className="editor-container">
-                    <FolderList />
-                    <MemoListContainer />
-                    <EditArea />
-                  </section>
+                  <EditorContainer />
                 </main>
               </ColorModeProvider>
             </ChakraProvider>

--- a/src/components/container/EditorContainer.tsx
+++ b/src/components/container/EditorContainer.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import {
+  DndContext,
+  DragOverlay,
+  DragStartEvent
+} from "@dnd-kit/core";
+import { Box } from "@chakra-ui/react";
+
+import { FolderList } from "@/components/container/FolderList";
+import { MemoListContainer } from "@/components/container/MemoList";
+import { EditArea } from "@/components/container/EditArea";
+import { MemoItem } from "@/components/parts/MemoItem";
+
+import { getMemoListQuery } from "@/utils/invoke/Memo";
+import { useFolderStore } from "@/utils/stores/folder";
+
+export const EditorContainer = () => {
+  const selectedFolderId = useFolderStore((state) => state.selectedFolderId);
+  const { data } = getMemoListQuery({
+    folderId: selectedFolderId,
+  });
+
+  const [draggingItem, setDraggingItem] = useState<{
+    memoId: number;
+    memoName: string;
+    memoUpdatedAt: string;
+  } | null>(null);
+
+  const handleDragStart = (event: DragStartEvent) => {
+    const memoId = Number(event.active.id);
+    if (isNaN(memoId)) return;
+
+    const memo = data?.find((memo) => memo.id === memoId);
+    if (!memo) return;
+
+    setDraggingItem({
+      memoId: memo.id,
+      memoName: memo.title,
+      memoUpdatedAt: memo.updated_at,
+    });
+  };
+
+  const handleDragEnd = () => {
+    setDraggingItem(null);
+  };
+
+  return (
+    <DndContext onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+      <section className="editor-container">
+        <FolderList />
+        <MemoListContainer />
+        <DragOverlay>
+          {draggingItem && (
+            <Box w={240}>
+              <MemoItem
+                id={draggingItem.memoId}
+                name={draggingItem.memoName}
+                updatedAt={draggingItem.memoUpdatedAt}
+                onClickMemo={() => {}}
+                onClickMoveFolder={() => {}}
+                onClickRenameMemo={() => {}}
+                onClickDeleteMemo={() => {}}
+              />
+            </Box>
+          )}
+        </DragOverlay>
+        <EditArea />
+      </section>
+    </DndContext>
+  );
+};

--- a/src/components/container/EditorContainer.tsx
+++ b/src/components/container/EditorContainer.tsx
@@ -54,8 +54,11 @@ export const EditorContainer = () => {
     // メモをdropして、フォルダが存在する場合は所属フォルダを移動する
     const memoId = Number(event.active.id);
     if (isNaN(memoId)) return;
-    const folderId = Number(event.over?.id);
-    if (isNaN(folderId)) return;
+    // ドロップ先のフォルダのIDを取得
+    const folderIdStr = event.over?.id.toString().split("-");
+    if (!folderIdStr || folderIdStr[0] !== "folder") return;
+    // 未分類の場合はnull
+    const folderId = folderIdStr[1] !== "null" ? Number(folderIdStr[1]) : null;
 
     setCustomDropAnimation(null);
 
@@ -67,6 +70,9 @@ export const EditorContainer = () => {
     })
       .then(() => {
         refetchGetMemoList();
+      })
+      .catch((error) => {
+        console.error(error);
       })
       .finally(() => {
         setDraggingItem(null);

--- a/src/components/parts/FolderItem.tsx
+++ b/src/components/parts/FolderItem.tsx
@@ -33,7 +33,7 @@ export const FolderItem = ({
   onClickRename,
 }: FolderProps) => {
   const { setNodeRef, isOver } = useDroppable({
-    id: folderId?.toString() ?? "",
+    id: `folder-${folderId?.toString() ?? "null"}`,
   });
 
   const handleClick = () => {

--- a/src/components/parts/FolderItem.tsx
+++ b/src/components/parts/FolderItem.tsx
@@ -11,6 +11,7 @@ import {
   MenuRoot,
   MenuTrigger,
 } from "@/components/ui/menu";
+import { useDroppable } from "@dnd-kit/core";
 
 export type FolderProps = {
   folderId: number | null;
@@ -31,6 +32,10 @@ export const FolderItem = ({
   onClickDelete,
   onClickRename,
 }: FolderProps) => {
+  const { setNodeRef, isOver } = useDroppable({
+    id: folderId?.toString() ?? "",
+  });
+
   const handleClick = () => {
     onClick(folderId);
   };
@@ -49,7 +54,8 @@ export const FolderItem = ({
     <Box
       position="relative"
       borderWidth={1}
-      borderColor="bg.subtle"
+      borderColor={isOver ? "border.inverted" : "bg.subtle"}
+      transition="border-color 0.2s ease-in-out"
       bg={selected ? "bg.emphasized" : "bg.subtle"}
       p={2}
       cursor="pointer"
@@ -57,6 +63,7 @@ export const FolderItem = ({
         borderColor: "border.inverted",
       }}
       onClick={selected ? undefined : handleClick}
+      ref={setNodeRef}
     >
       {memoCounts !== undefined ? (
         <Float placement="top-end" offsetX={3}>

--- a/src/components/parts/MemoItem.tsx
+++ b/src/components/parts/MemoItem.tsx
@@ -39,7 +39,7 @@ export const MemoItem = ({
   onClickRenameMemo,
   onClickDeleteMemo,
 }: MemoItemProps) => {
-  const { attributes, listeners, setNodeRef, transform } = useDraggable({
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
     id: id,
   });
 
@@ -68,10 +68,14 @@ export const MemoItem = ({
       _hover={{
         bg: "bg.emphasized",
       }}
-      onClick={() => onClickMemo(id)}
+      onClick={() => {
+        if (isDragging) return;
+        onClickMemo(id);
+      }}
       style={{
         transform: CSS.Transform.toString(transform),
       }}
+      {...attributes}
       ref={setNodeRef}
     >
       {resultIcon ? (
@@ -87,7 +91,6 @@ export const MemoItem = ({
           style={{
             cursor: "move",
           }}
-          {...attributes}
           {...listeners}
         >
           <HiOutlineViewList />

--- a/src/components/parts/MemoItem.tsx
+++ b/src/components/parts/MemoItem.tsx
@@ -1,3 +1,6 @@
+import { useDraggable } from "@dnd-kit/core";
+import { CSS } from "@dnd-kit/utilities";
+
 import { Box, Text, HStack, IconButton, Float, Circle } from "@chakra-ui/react";
 import {
   HiDotsHorizontal,
@@ -35,6 +38,10 @@ export const MemoItem = ({
   onClickRenameMemo,
   onClickDeleteMemo,
 }: MemoItemProps) => {
+  const { attributes, listeners, setNodeRef, transform } = useDraggable({
+    id: id,
+  });
+
   const handleSelectMenu: React.ComponentProps<typeof MenuRoot>["onSelect"] = (
     select
   ) => {
@@ -48,71 +55,78 @@ export const MemoItem = ({
   };
 
   return (
-      <Box
-        position="relative"
-        boxShadow="sm"
-        bg={selected ? "bg.subtle" : "bg"}
-        p={1}
-        cursor="pointer"
-        as="button"
-        textAlign="left"
-        _hover={{
-          bg: "bg.emphasized",
-        }}
-        onClick={() => onClickMemo(id)}
-      >
-        {resultIcon ? (
-          <Float placement="top-end">
-            <Circle size={3} bg="teal.emphasized"></Circle>
-          </Float>
-        ) : null}
-        <HStack justifyContent="space-between" alignItems="center">
-          <Box w="100%">
-            <Text textStyle="sm">{name}</Text>
-            <Text color="fg.subtle" textStyle="xs">
-              {updatedAt}
-            </Text>
-          </Box>
-          <MenuRoot onSelect={handleSelectMenu}>
-            <MenuTrigger asChild>
-              <IconButton
-                size="xs"
-                aria-label="More options"
-                variant="outline"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <HiDotsHorizontal />
-              </IconButton>
-            </MenuTrigger>
-            <MenuContent>
-              <MenuItem
-                value="move-folder"
-                cursor="pointer"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <HiFolderOpen />
-                <Box flex="1">フォルダ移動</Box>
-              </MenuItem>
-              <MenuItem
-                value="rename-memo"
-                cursor="pointer"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <HiPencil />
-                <Box flex="1">名前変更</Box>
-              </MenuItem>
-              <MenuItem
-                value="delete-memo"
-                cursor="pointer"
-                color="fg.error"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <HiTrash />
-                <Box flex="1">削除</Box>
-              </MenuItem>
-            </MenuContent>
-          </MenuRoot>
-        </HStack>
-      </Box>
+    <Box
+      position="relative"
+      w="100%"
+      boxShadow="sm"
+      bg={selected ? "bg.subtle" : "bg"}
+      p={1}
+      cursor="pointer"
+      as="button"
+      textAlign="left"
+      _hover={{
+        bg: "bg.emphasized",
+      }}
+      onClick={() => onClickMemo(id)}
+      style={{
+        transform: CSS.Transform.toString(transform),
+      }}
+      ref={setNodeRef}
+      {...attributes}
+      {...listeners}
+    >
+      {resultIcon ? (
+        <Float placement="top-end">
+          <Circle size={3} bg="teal.emphasized"></Circle>
+        </Float>
+      ) : null}
+      <HStack justifyContent="space-between" alignItems="center">
+        <Box w="100%">
+          <Text textStyle="sm">{name}</Text>
+          <Text color="fg.subtle" textStyle="xs">
+            {updatedAt}
+          </Text>
+        </Box>
+        <MenuRoot onSelect={handleSelectMenu}>
+          <MenuTrigger asChild>
+            <IconButton
+              size="xs"
+              aria-label="More options"
+              variant="outline"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <HiDotsHorizontal />
+            </IconButton>
+          </MenuTrigger>
+          <MenuContent>
+            <MenuItem
+              value="move-folder"
+              cursor="pointer"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <HiFolderOpen />
+              <Box flex="1">フォルダ移動</Box>
+            </MenuItem>
+            <MenuItem
+              value="rename-memo"
+              cursor="pointer"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <HiPencil />
+              <Box flex="1">名前変更</Box>
+            </MenuItem>
+            <MenuItem
+              value="delete-memo"
+              cursor="pointer"
+              color="fg.error"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <HiTrash />
+              <Box flex="1">削除</Box>
+            </MenuItem>
+          </MenuContent>
+        </MenuRoot>
+      </HStack>
+    </Box>
   );
 };

--- a/src/components/parts/MemoItem.tsx
+++ b/src/components/parts/MemoItem.tsx
@@ -11,7 +11,6 @@ import {
   MenuRoot,
   MenuTrigger,
 } from "@/components/ui/menu";
-import { Tooltip } from "@/components/ui/tooltip";
 
 export type MemoItemProps = {
   id: number;
@@ -49,13 +48,6 @@ export const MemoItem = ({
   };
 
   return (
-    <Tooltip
-      content={
-        <Text color="fg.subtle" textStyle="sm">
-          last updated: {updatedAt}
-        </Text>
-      }
-    >
       <Box
         position="relative"
         boxShadow="sm"
@@ -122,6 +114,5 @@ export const MemoItem = ({
           </MenuRoot>
         </HStack>
       </Box>
-    </Tooltip>
   );
 };

--- a/src/components/parts/MemoItem.tsx
+++ b/src/components/parts/MemoItem.tsx
@@ -7,6 +7,7 @@ import {
   HiFolderOpen,
   HiTrash,
   HiPencil,
+  HiOutlineViewList,
 } from "react-icons/hi";
 import {
   MenuContent,
@@ -72,8 +73,6 @@ export const MemoItem = ({
         transform: CSS.Transform.toString(transform),
       }}
       ref={setNodeRef}
-      {...attributes}
-      {...listeners}
     >
       {resultIcon ? (
         <Float placement="top-end">
@@ -81,6 +80,18 @@ export const MemoItem = ({
         </Float>
       ) : null}
       <HStack justifyContent="space-between" alignItems="center">
+        <IconButton
+          size="xs"
+          aria-label="move"
+          variant="ghost"
+          style={{
+            cursor: "move",
+          }}
+          {...attributes}
+          {...listeners}
+        >
+          <HiOutlineViewList />
+        </IconButton>
         <Box w="100%">
           <Text textStyle="sm">{name}</Text>
           <Text color="fg.subtle" textStyle="xs">

--- a/src/components/presentation/MemoList.tsx
+++ b/src/components/presentation/MemoList.tsx
@@ -43,6 +43,7 @@ export const MemoList: React.FC<MemoListProps> = ({
       w={240}
       maxH="100vh"
       overflowY="auto"
+      overscrollBehavior="none"
       pb={3}
       bg="bg"
       borderRightWidth={1}


### PR DESCRIPTION
## 関連するissue

- なし

## 概要

メモをDnDで動かす機能を追加

<img width="725" alt="スクリーンショット 2025-06-18 22 17 39" src="https://github.com/user-attachments/assets/dc98abc9-5244-4cef-963b-adbe40b55707" />

## 変更内容

- [ ] バグ修正
- [x] 新機能
- [ ] その他

## チェックリスト

- [x] コードがプロジェクトのスタイルガイドラインに従っている
- [x] 自己レビューを行った
- [x] 必要なドキュメントを更新した

---

このPRがプロジェクトをより良くする一歩です。
レビューを楽しみにしています！


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - メモのドラッグ＆ドロップによるフォルダ間の移動機能を追加しました。

- **改善**
  - エディターエリアを1つのコンポーネントに統合し、操作性を向上しました。
  - フォルダとメモ一覧のUIがドラッグ＆ドロップに対応しました。
  - メモリストのスクロール時のバウンス効果を無効化しました。

- **依存関係**
  - ドラッグ＆ドロップ機能のために `@dnd-kit/core` を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->